### PR TITLE
Make purging of share optional

### DIFF
--- a/manifests/share.pp
+++ b/manifests/share.pp
@@ -29,7 +29,14 @@ define zfs::share (
   if $share_title {
     $share_name = $share_title
   } else {
-    $share_name = regsubst($vol_name, '/', '_', 'G')
+    case $vol_name {
+      /\//: {
+        $share_name = regsubst($vol_name, '/', '_', 'G')
+      }
+      default: {
+        $share_name = $vol_name
+      }
+    }
   }
 
   if $allow_ip {


### PR DESCRIPTION
This commit updates zfs share to make purging optional and disabled by
default. Without this change if a zfs share differs from what you're
setting then puppet destroys it before setting the new share.
Additionally, a case statement used for setting share name is
simplified.
