### PR TITLE
Remove an unnecessary case statement

### DIFF
--- a/manifests/share.pp
+++ b/manifests/share.pp
@@ -29,14 +29,7 @@ define zfs::share (
   if $share_title {
     $share_name = $share_title
   } else {
-    case $vol_name {
-      /\//: {
-        $share_name = regsubst($vol_name, '/', '_', 'G')
-      }
-      default: {
-        $share_name = $vol_name
-      }
-    }
+    $share_name = regsubst($vol_name, '/', '_', 'G')
   }
 
   if $allow_ip {


### PR DESCRIPTION
This commit removes a case statement used to check if a string contains a / before running regsubst. Since it will do nothing if run on a string without a / it's cleaner to remove the case statement.
