### PR TITLE
Add solaris 11.3 to zfs_share provider confine

### DIFF
--- a/lib/puppet/provider/zfs_share/solaris11.rb
+++ b/lib/puppet/provider/zfs_share/solaris11.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:zfs_share).provide(:solaris, :parent => PuppetX::Puppetlabs::
   desc "ZFS share support for Solaris 11"
 
   confine :operatingsystem => :solaris
-  confine :operatingsystemrelease => 11.2
+  confine :operatingsystemrelease => [ 11.2, 11.3 ]
 
   commands :zfs => 'zfs'
 


### PR DESCRIPTION
This commit adds solaris 11.3 to the zfs_share provider. Without this change the provider reports it is not available for 11.3
