### PR TITLE
(maint) Quote file modes

### DIFF
--- a/manifests/snapshots.pp
+++ b/manifests/snapshots.pp
@@ -2,9 +2,9 @@ class zfs::snapshots {
 
   file { '/usr/local/bin/zfs-snapshot.rb':
     source => 'puppet:///modules/zfs/zfs-snapshot.rb',
-    owner  => root,
+    owner  => 'root',
     group  => 0,
-    mode   => 0750,
+    mode   => '0750',
   }
 
   $env = $operatingsystem ? {


### PR DESCRIPTION
This quotes the value of the `mode` parameter on the `file` resource in
`zfs::snapshots` for compatibility with puppet 4. It also quotes the
value `root` on the `owner` parameter for style.
