### PR TITLE
Update snapshot rotation

### DIFF
--- a/files/zfs_snapshot.py
+++ b/files/zfs_snapshot.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""
+Create and rotate zfs snapshots
+"""
+
+import subprocess
+import time
+import argparse
+import os
+
+
+def str2bool(v):
+    return str(v.lower()) in ("yes", "true", "t", "1")
+
+def get_args():
+    """
+    Get arguments
+    """
+    parse = argparse.ArgumentParser(description='ZFS snapshot helper')
+    parse.register('type', 'bool', str2bool)
+    parse.add_argument('-V', '--volume',
+                       help='Volume to create snapshot for',
+                       required=True,
+                       type=str)
+    parse.add_argument('-k', '--keep',
+                       help='Rotate any snapshots beyond this number',
+                       type=int)
+    parse.add_argument('-t', '--snapshot_title',
+                       help='Snapshot title. Defaults to local date/time.',
+                       type=str)
+    parse.add_argument('-S', '--take_snapshot',
+                       help='Enable or disable snapshot creation. Default: True',
+                       type=bool,
+                       default=True)
+
+    args = parse.parse_args()
+    return args
+
+def take_snapshot(volume, title=None):
+    """
+    Create a zfs snapshot with todays date
+    """
+    if title:
+        title = title
+    else:
+        title = time.strftime("%Y-%m-%d-%H-%M", time.localtime())
+    snapshot_title = volume + '@' + title
+    devnull = open(os.devnull, 'r+b', 0)
+    snapshot = subprocess.call(['zfs', 'snapshot', snapshot_title], stdout=devnull, stderr=devnull)
+    if snapshot == 0:
+        return True
+    else:
+        return False
+
+def rotate_snapshot(volume, keep):
+    """
+    Rotate snapshots. Keep the number specified in keep.
+
+    This rotates snapshots above the number in keep. It determines this based on the count provided.
+    """
+    output = subprocess.check_output(['zfs', 'list', '-r', '-t', 'snapshot', '-o', 'name', volume])
+    if output:
+        snapshots = output.strip().split('\n')[1:]
+        snapshots.reverse()
+        to_remove = snapshots[keep:]
+        if len(to_remove):
+            for snapshot in to_remove:
+                subprocess.check_output(['zfs', 'destroy', snapshot])
+            return 'Destroyed {} snapshots'.format(len(to_remove))
+        else:
+            return False
+    else:
+        return False
+
+def main():
+    args = get_args()
+    if args.take_snapshot:
+        if take_snapshot(args.volume, args.snapshot_title):
+            print 'Created snapshot'
+    if args.keep:
+        rotate = rotate_snapshot(args.volume, args.keep)
+        if rotate:
+            print rotate
+
+if __name__ == '__main__':
+    main()

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -1,0 +1,20 @@
+# Provide the zfs python library and scripts for supporting send/recv
+class zfs::pip (
+  $ensure  = latest,
+  $repo    = undef,
+  $include = false,
+) {
+  if $include == true {
+    python::pip { 'zfs':
+      ensure       => $ensure,
+      install_args => $repo,
+    }
+  } else {
+    file { '/usr/local/bin/zfs_snapshot':
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0555',
+      source => 'puppet:///modules/zfs/zfs_snapshot.py',
+    }
+  }
+}

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -1,32 +1,32 @@
 # Define type for creating snapshots on specific volumes at a specified time
 define zfs::snapshot (
+  $target,  #path before title
   $hour   = '1',
   $minute = '0',
-  $rhour  = '1',
-  $rmin   = '4',
-  $zfs    = '/usr/sbin/zfs',
-  $rotate = 'true',
+  $rhour  = '1', #toremove
+  $rmin   = '4', #toremove
+  $zfs    = '/usr/sbin/zfs', #toremove
+  $path   = '/usr/local/bin',
+  $rotate = true,
   $keep   = '8',
   $user   = 'root',
-  $target   #path before title
 ) {
 
-  $date     = '$(/usr/bin/date +\%Y-\%m-\%d-\%H-\%M)'
-  $snapshot = "$zfs snapshot $target/$title@$date"
+  include ::zfs::pip
 
-  cron { "$title-snapshot":
-    command => $snapshot,
-    user    => 'root',
-    hour    => $hour,
-    minute  => $minute
+  $volume = "${target}/${title}"
+  $snap = "${path}/zfs_snapshot --volume ${volume}"
+  if $rotate {
+    $rotation = "--keep ${keep}"
+    $command  = join([$snap, $rotation], ' ')
+  } else {
+    $command = $snap
   }
 
-  if ( $rotate == 'true' ) {
-    zfs::rotate { "$target/$title":
-      rotate_hour   => $rhour,
-      rotate_minute => $rmin,
-      keep          => $keep,
-      user          => $user,
-    }
+  cron { "${title}-snapshot":
+    command     => $command,
+    user        => 'root',
+    hour        => $hour,
+    minute      => $minute,
   }
 }


### PR DESCRIPTION
This commit updates snapshot rotation to utilize zfs_snapshot, which
allows for placing the device performing snapshots and rotation into a
matinenance mode where it will halt operations. Without
this change no such concept exists. Additionally, it required two
separate operations to take a snapshot and rotate snapshots, where now
that is a single operation from cron's perspective.
