### PR TITLE
Exclude haszfs check on Windows

### DIFF
--- a/lib/facter/haszfs.rb
+++ b/lib/facter/haszfs.rb
@@ -1,17 +1,13 @@
 Facter.add("haszfs") do
-
-  # By default Solaris doesn't include the filesystem.
-  if Facter.value('operatingsystem') == 'Solaris'
-    mountcmd='mount -v'
-  else
-    mountcmd='mount'
-  end
-
   setcode do
-    if `#{mountcmd}` !~ /zfs/
+    case Facter.value('operatingsystem')
+    when "windows"
       false
+    when "Solaris"
+      # By default Solaris doesn't include the filesystem.
+      `mount -v` =~ /zfs/ ? true : false
     else
-      true
+      `mount` =~ /zfs/ ? true : false
     end
   end
 end


### PR DESCRIPTION
Fixes the `haszfs` failure on Windows hosts, see https://tickets.puppetlabs.com/browse/OPS-11799